### PR TITLE
[docs] add link to article

### DIFF
--- a/prefect-scheduled-scoring/README.md
+++ b/prefect-scheduled-scoring/README.md
@@ -1,0 +1,3 @@
+# prefect-scheduled-scoring
+
+The files in this directory were created to support ["Using a scheduled prefect flow with a Saturn Dask cluster"](http://docs.saturncloud.io/en/articles/4135965-using-a-scheduled-prefect-flow-with-a-saturn-dask-cluster)


### PR DESCRIPTION
This pull request adds a `README.md` to the prefect scheduled scoring example, with a link to the article it supports.