### PR TITLE
add XGBoost notebooks

### DIFF
--- a/taxi_demo/machine_learning/tip_dask_xgboost.ipynb
+++ b/taxi_demo/machine_learning/tip_dask_xgboost.ipynb
@@ -1,0 +1,635 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Tip Prediction (XGBoost + Dask)\n",
+    "\n",
+    "**Hardware**: r5.8xlarge (32 CPU, 256 GB RAM)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dask_xgboost as dxgb\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "from dask.distributed import Client, wait\n",
+    "from dask_saturn import SaturnCluster\n",
+    "\n",
+    "from sklearn.metrics import mean_squared_error\n",
+    "\n",
+    "from ml_utils import MLUtils"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To begin, initialize an `ml_utils` object. This is a small object used to handle naming and storing the model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ml_utils = MLUtils(\n",
+    "    ml_task='tip',\n",
+    "    tool='dask',\n",
+    "    model='xgboost',\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Set up a Dask cluster\n",
+    "\n",
+    "Create a Dask Cluster with the following specs.\n",
+    "\n",
+    "* 10 workers, each:\n",
+    "    - `r5.8xlarge` EC2 instances\n",
+    "    - `nproc=1` (one worker process per instance)\n",
+    "    - `nthreads=32` (use all available cores)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[2020-08-07 18:15:29] INFO - dask-saturn | Starting cluster. Status: stopped\n",
+      "[2020-08-07 18:15:38] INFO - dask-saturn | Starting cluster. Status: starting\n",
+      "[2020-08-07 18:15:54] INFO - dask-saturn | Starting cluster. Status: starting\n",
+      "[2020-08-07 18:16:25] INFO - dask-saturn | Starting cluster. Status: starting\n",
+      "[2020-08-07 18:17:13] INFO - dask-saturn | Starting cluster. Status: starting\n",
+      "[2020-08-07 18:18:09] INFO - dask-saturn | Starting cluster. Status: starting\n",
+      "[2020-08-07 18:18:54] INFO - dask-saturn | Starting cluster. Status: starting\n",
+      "[2020-08-07 18:19:46] INFO - dask-saturn | Starting cluster. Status: starting\n",
+      "[2020-08-07 18:20:34] INFO - dask-saturn | Starting cluster. Status: starting\n",
+      "[2020-08-07 18:21:14] INFO - dask-saturn | Starting cluster. Status: starting\n",
+      "[2020-08-07 18:22:06] INFO - dask-saturn | Cluster is ready\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3883e8d51c674dd78408aa5bdc86e309",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HTML(value='<h2>SaturnCluster</h2>'), HBox(children=(HTML(value='\\n<div>\\n  <style scoped>\\n   …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "cluster = SaturnCluster(\n",
+    "    n_workers=10,\n",
+    "    scheduler_size='xlarge',\n",
+    "    worker_size='8xlarge',\n",
+    "    nproc=1,\n",
+    "    nthreads=32\n",
+    ")\n",
+    "client = Client(cluster)\n",
+    "cluster"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Load data and feature engineering"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 5.33 s, sys: 4.09 s, total: 9.42 s\n",
+      "Wall time: 28.2 s\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "(10994913, 10)"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "tip_train = ml_utils.read_parquet_dir(f'{ml_utils.taxi_path}/data/ml/tip_train_sample')\n",
+    "tip_train.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>pickup_taxizone_id</th>\n",
+       "      <th>dropoff_taxizone_id</th>\n",
+       "      <th>pickup_weekday</th>\n",
+       "      <th>pickup_weekofyear</th>\n",
+       "      <th>pickup_hour</th>\n",
+       "      <th>pickup_minute</th>\n",
+       "      <th>pickup_week_hour</th>\n",
+       "      <th>passenger_count</th>\n",
+       "      <th>tip_fraction</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>28a18fa5fa2f44f29ffd98fc9159829d</td>\n",
+       "      <td>238.0</td>\n",
+       "      <td>132.0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>29</td>\n",
+       "      <td>7</td>\n",
+       "      <td>19</td>\n",
+       "      <td>7</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.199616</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>a6578145ff824f5fb94e90457b040883</td>\n",
+       "      <td>236.0</td>\n",
+       "      <td>246.0</td>\n",
+       "      <td>6</td>\n",
+       "      <td>28</td>\n",
+       "      <td>9</td>\n",
+       "      <td>16</td>\n",
+       "      <td>153</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.130435</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>91726ecac3b44e8bbfea68d725f35556</td>\n",
+       "      <td>90.0</td>\n",
+       "      <td>148.0</td>\n",
+       "      <td>6</td>\n",
+       "      <td>28</td>\n",
+       "      <td>22</td>\n",
+       "      <td>44</td>\n",
+       "      <td>166</td>\n",
+       "      <td>6.0</td>\n",
+       "      <td>0.166667</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>a3b0d14ad1644dd6b90f1af6be002e55</td>\n",
+       "      <td>141.0</td>\n",
+       "      <td>186.0</td>\n",
+       "      <td>6</td>\n",
+       "      <td>28</td>\n",
+       "      <td>9</td>\n",
+       "      <td>34</td>\n",
+       "      <td>153</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.152299</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>70aa5a0c6bc147dd8553e201b63ba0fe</td>\n",
+       "      <td>100.0</td>\n",
+       "      <td>142.0</td>\n",
+       "      <td>6</td>\n",
+       "      <td>28</td>\n",
+       "      <td>22</td>\n",
+       "      <td>7</td>\n",
+       "      <td>166</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.169231</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                 id  pickup_taxizone_id  dropoff_taxizone_id  \\\n",
+       "0  28a18fa5fa2f44f29ffd98fc9159829d               238.0                132.0   \n",
+       "1  a6578145ff824f5fb94e90457b040883               236.0                246.0   \n",
+       "2  91726ecac3b44e8bbfea68d725f35556                90.0                148.0   \n",
+       "3  a3b0d14ad1644dd6b90f1af6be002e55               141.0                186.0   \n",
+       "4  70aa5a0c6bc147dd8553e201b63ba0fe               100.0                142.0   \n",
+       "\n",
+       "   pickup_weekday  pickup_weekofyear  pickup_hour  pickup_minute  \\\n",
+       "0               0                 29            7             19   \n",
+       "1               6                 28            9             16   \n",
+       "2               6                 28           22             44   \n",
+       "3               6                 28            9             34   \n",
+       "4               6                 28           22              7   \n",
+       "\n",
+       "   pickup_week_hour  passenger_count  tip_fraction  \n",
+       "0                 7              1.0      0.199616  \n",
+       "1               153              1.0      0.130435  \n",
+       "2               166              6.0      0.166667  \n",
+       "3               153              1.0      0.152299  \n",
+       "4               166              1.0      0.169231  "
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tip_train.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<br>\n",
+    "Take a sample of the training data, then drop the full `train` to save memory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(1099491, 10)"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sample = tip_train.sample(frac=0.1, replace=False, random_state=42)\n",
+    "sample.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "del tip_train"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Train a model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xgb_reg = dxgb.train(\n",
+    "    client=client,\n",
+    "    objective=\"reg:squarederror\",\n",
+    "    learning_rate=0.1,\n",
+    "    max_depth=8,\n",
+    "    n_estimators=100,\n",
+    "    nthread=32\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 9min 52s, sys: 11.6 s, total: 10min 4s\n",
+      "Wall time: 19.1 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "features = ml_utils.tip_vars.features\n",
+    "y_col = ml_utils.tip_vars.y_col\n",
+    "model = xgb_reg.fit(X=sample[features], y=sample[y_col].values)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Save model\n",
+    "\n",
+    "Now that we've trained a model, store it in S3 so it can be deployed in the future."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "uploading model to 's3://saturn-titan/nyc-taxi/ml_results/models/tip__scikit__xgboost.pkl'\n",
+      "successfully uploaded model\n"
+     ]
+    }
+   ],
+   "source": [
+    "ml_utils.write_model(model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Predict on test set\n",
+    "\n",
+    "And calculate metrics. Save predictions and metrics to S3. Before doing that, remove the training data from memory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "del sample"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 15 s, sys: 11.5 s, total: 26.5 s\n",
+      "Wall time: 1min 4s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "amt_test = ml_utils.read_parquet_dir(f'{ml_utils.taxi_path}/data/ml/tip_test')\n",
+    "preds = amt_test[['id', y_col]].copy()\n",
+    "preds.columns = ['id', 'actual']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "preds['predicted'] = model.predict(amt_test[features])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>actual</th>\n",
+       "      <th>predicted</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>8e8109754e3e4cb7879c4e9ee216d58d</td>\n",
+       "      <td>0.097087</td>\n",
+       "      <td>0.161691</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>a30e7c87866f417ab15dee5617f272a0</td>\n",
+       "      <td>0.166667</td>\n",
+       "      <td>0.158902</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1a7a611d0809489d99a5120727e0476a</td>\n",
+       "      <td>0.120000</td>\n",
+       "      <td>0.158882</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>736e84ca12a640cc858c210bd58f744c</td>\n",
+       "      <td>0.089474</td>\n",
+       "      <td>0.157415</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>f2c24299d9a34ce986b7a271c5cc80b2</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.147651</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                 id    actual  predicted\n",
+       "0  8e8109754e3e4cb7879c4e9ee216d58d  0.097087   0.161691\n",
+       "1  a30e7c87866f417ab15dee5617f272a0  0.166667   0.158902\n",
+       "2  1a7a611d0809489d99a5120727e0476a  0.120000   0.158882\n",
+       "3  736e84ca12a640cc858c210bd58f744c  0.089474   0.157415\n",
+       "4  f2c24299d9a34ce986b7a271c5cc80b2  0.000000   0.147651"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "preds.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Writing predictions to 's3://saturn-titan/nyc-taxi/ml_results/predictions/tip__scikit__xgboost'\n",
+      "Done writing predictions\n",
+      "CPU times: user 10.1 s, sys: 2.1 s, total: 12.2 s\n",
+      "Wall time: 1min 12s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "ml_utils.write_predictions(preds)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>ml_task</th>\n",
+       "      <th>tool</th>\n",
+       "      <th>model</th>\n",
+       "      <th>metric</th>\n",
+       "      <th>value</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>tip</td>\n",
+       "      <td>scikit</td>\n",
+       "      <td>xgboost</td>\n",
+       "      <td>rmse</td>\n",
+       "      <td>0.05157</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  ml_task    tool    model metric    value\n",
+       "0     tip  scikit  xgboost   rmse  0.05157"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rmse = mean_squared_error(preds.actual, preds.predicted, squared=False)\n",
+    "ml_utils.write_metric_df('rmse', rmse)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/taxi_demo/machine_learning/tip_dask_xgboost.ipynb
+++ b/taxi_demo/machine_learning/tip_dask_xgboost.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -19,6 +19,7 @@
     "import numpy as np\n",
     "import pandas as pd\n",
     "\n",
+    "import dask.dataframe as dd\n",
     "from dask.distributed import Client, wait\n",
     "from dask_saturn import SaturnCluster\n",
     "\n",
@@ -36,7 +37,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -63,30 +64,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2020-08-07 18:15:29] INFO - dask-saturn | Starting cluster. Status: stopped\n",
-      "[2020-08-07 18:15:38] INFO - dask-saturn | Starting cluster. Status: starting\n",
-      "[2020-08-07 18:15:54] INFO - dask-saturn | Starting cluster. Status: starting\n",
-      "[2020-08-07 18:16:25] INFO - dask-saturn | Starting cluster. Status: starting\n",
-      "[2020-08-07 18:17:13] INFO - dask-saturn | Starting cluster. Status: starting\n",
-      "[2020-08-07 18:18:09] INFO - dask-saturn | Starting cluster. Status: starting\n",
-      "[2020-08-07 18:18:54] INFO - dask-saturn | Starting cluster. Status: starting\n",
-      "[2020-08-07 18:19:46] INFO - dask-saturn | Starting cluster. Status: starting\n",
-      "[2020-08-07 18:20:34] INFO - dask-saturn | Starting cluster. Status: starting\n",
-      "[2020-08-07 18:21:14] INFO - dask-saturn | Starting cluster. Status: starting\n",
-      "[2020-08-07 18:22:06] INFO - dask-saturn | Cluster is ready\n"
+      "[2020-08-07 19:23:15] INFO - dask-saturn | Cluster is ready\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3883e8d51c674dd78408aa5bdc86e309",
+       "model_id": "0cf7e06a60ce4dfa98d6e371d3ce5cc8",
        "version_major": 2,
        "version_minor": 0
       },
@@ -119,32 +110,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU times: user 5.33 s, sys: 4.09 s, total: 9.42 s\n",
-      "Wall time: 28.2 s\n"
+     "ename": "PermissionError",
+     "evalue": "Access Denied",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mClientError\u001b[0m                               Traceback (most recent call last)",
+      "\u001b[0;32m/srv/conda/envs/saturn/lib/python3.7/site-packages/s3fs/core.py\u001b[0m in \u001b[0;36m_lsdir\u001b[0;34m(self, path, refresh, max_items)\u001b[0m\n\u001b[1;32m    393\u001b[0m                 \u001b[0mdircache\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 394\u001b[0;31m                 \u001b[0;32mfor\u001b[0m \u001b[0mi\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mit\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    395\u001b[0m                     \u001b[0mdircache\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mextend\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mi\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'CommonPrefixes'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/srv/conda/envs/saturn/lib/python3.7/site-packages/botocore/paginate.py\u001b[0m in \u001b[0;36m__iter__\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    254\u001b[0m         \u001b[0;32mwhile\u001b[0m \u001b[0;32mTrue\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 255\u001b[0;31m             \u001b[0mresponse\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_make_request\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcurrent_kwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    256\u001b[0m             \u001b[0mparsed\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_extract_parsed_response\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mresponse\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/srv/conda/envs/saturn/lib/python3.7/site-packages/botocore/paginate.py\u001b[0m in \u001b[0;36m_make_request\u001b[0;34m(self, current_kwargs)\u001b[0m\n\u001b[1;32m    331\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m_make_request\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcurrent_kwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 332\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_method\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m**\u001b[0m\u001b[0mcurrent_kwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    333\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/srv/conda/envs/saturn/lib/python3.7/site-packages/botocore/client.py\u001b[0m in \u001b[0;36m_api_call\u001b[0;34m(self, *args, **kwargs)\u001b[0m\n\u001b[1;32m    275\u001b[0m             \u001b[0;31m# The \"self\" in this scope is referring to the BaseClient.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 276\u001b[0;31m             \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_make_api_call\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0moperation_name\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    277\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/srv/conda/envs/saturn/lib/python3.7/site-packages/botocore/client.py\u001b[0m in \u001b[0;36m_make_api_call\u001b[0;34m(self, operation_name, api_params)\u001b[0m\n\u001b[1;32m    585\u001b[0m             \u001b[0merror_class\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mexceptions\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfrom_code\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0merror_code\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 586\u001b[0;31m             \u001b[0;32mraise\u001b[0m \u001b[0merror_class\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mparsed_response\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0moperation_name\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    587\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mClientError\u001b[0m: An error occurred (AccessDenied) when calling the ListObjectsV2 operation: Access Denied",
+      "\nDuring handling of the above exception, another exception occurred:\n",
+      "\u001b[0;31mPermissionError\u001b[0m                           Traceback (most recent call last)",
+      "\u001b[0;32m<timed exec>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n",
+      "\u001b[0;32m/srv/conda/envs/saturn/lib/python3.7/site-packages/dask/dataframe/io/parquet/core.py\u001b[0m in \u001b[0;36mread_parquet\u001b[0;34m(path, columns, filters, categories, index, storage_options, engine, gather_statistics, split_row_groups, chunksize, **kwargs)\u001b[0m\n\u001b[1;32m    231\u001b[0m         \u001b[0mfilters\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mfilters\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    232\u001b[0m         \u001b[0msplit_row_groups\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0msplit_row_groups\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 233\u001b[0;31m         \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    234\u001b[0m     )\n\u001b[1;32m    235\u001b[0m     \u001b[0;32mif\u001b[0m \u001b[0mmeta\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mindex\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mname\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/srv/conda/envs/saturn/lib/python3.7/site-packages/dask/dataframe/io/parquet/arrow.py\u001b[0m in \u001b[0;36mread_metadata\u001b[0;34m(fs, paths, categories, index, gather_statistics, filters, split_row_groups, **kwargs)\u001b[0m\n\u001b[1;32m    137\u001b[0m         \u001b[0;31m# correspond to a row group (populated below)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    138\u001b[0m         parts, dataset = _determine_dataset_parts(\n\u001b[0;32m--> 139\u001b[0;31m             \u001b[0mfs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mpaths\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mgather_statistics\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfilters\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mkwargs\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"dataset\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m{\u001b[0m\u001b[0;34m}\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    140\u001b[0m         )\n\u001b[1;32m    141\u001b[0m         \u001b[0;31m# TODO: Call to `_determine_dataset_parts` uses `pq.ParquetDataset`\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/srv/conda/envs/saturn/lib/python3.7/site-packages/dask/dataframe/io/parquet/arrow.py\u001b[0m in \u001b[0;36m_determine_dataset_parts\u001b[0;34m(fs, paths, gather_statistics, filters, dataset_kwargs)\u001b[0m\n\u001b[1;32m     91\u001b[0m                 \u001b[0mdataset\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mpq\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mParquetDataset\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mpaths\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfilesystem\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mfs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mdataset_kwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     92\u001b[0m                 \u001b[0mparts\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0mbase\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0mfs\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msep\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0mfn\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0mfn\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mfns\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 93\u001b[0;31m     \u001b[0;32melif\u001b[0m \u001b[0mfs\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0misdir\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mpaths\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     94\u001b[0m         \u001b[0;31m# This is a directory, check for _metadata, then _common_metadata\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     95\u001b[0m         \u001b[0mallpaths\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfs\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mglob\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mpaths\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0mfs\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msep\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0;34m\"*\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/srv/conda/envs/saturn/lib/python3.7/site-packages/s3fs/core.py\u001b[0m in \u001b[0;36misdir\u001b[0;34m(self, path)\u001b[0m\n\u001b[1;32m    599\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    600\u001b[0m         \u001b[0;31m# This only returns things within the path and NOT the path object itself\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 601\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0mbool\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_lsdir\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mpath\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    602\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    603\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mls\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mpath\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdetail\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mFalse\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mrefresh\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mFalse\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/srv/conda/envs/saturn/lib/python3.7/site-packages/s3fs/core.py\u001b[0m in \u001b[0;36m_lsdir\u001b[0;34m(self, path, refresh, max_items)\u001b[0m\n\u001b[1;32m    407\u001b[0m                     \u001b[0mf\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'name'\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mf\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'Key'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    408\u001b[0m             \u001b[0;32mexcept\u001b[0m \u001b[0mClientError\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0me\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 409\u001b[0;31m                 \u001b[0;32mraise\u001b[0m \u001b[0mtranslate_boto_error\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0me\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    410\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    411\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdircache\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mpath\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfiles\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mPermissionError\u001b[0m: Access Denied"
      ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "(10994913, 10)"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
     "%%time\n",
-    "tip_train = ml_utils.read_parquet_dir(f'{ml_utils.taxi_path}/data/ml/tip_train_sample')\n",
-    "tip_train.shape"
+    "tip_train = dd.read_parquet(f'{ml_utils.taxi_path}/data/ml/tip_train_sample', engine='pyarrow')\n",
+    "len(tip_train)"
    ]
   },
   {

--- a/taxi_demo/machine_learning/tip_dask_xgboost.ipynb
+++ b/taxi_demo/machine_learning/tip_dask_xgboost.ipynb
@@ -15,11 +15,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import dask.dataframe as dd\n",
     "import dask_xgboost as dxgb\n",
     "import numpy as np\n",
     "import pandas as pd\n",
     "\n",
-    "import dask.dataframe as dd\n",
     "from dask.distributed import Client, wait\n",
     "from dask_saturn import SaturnCluster\n",
     "\n",
@@ -472,7 +472,8 @@
     }
    ],
    "source": [
-    "sample.persist()"
+    "sample = sample.persist()\n",
+    "_ = wait(sample)"
    ]
   },
   {
@@ -763,7 +764,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/taxi_demo/machine_learning/tip_dask_xgboost.ipynb
+++ b/taxi_demo/machine_learning/tip_dask_xgboost.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -32,12 +32,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "This notebook relies on `xgboost` 0.90 and `dask-xgboost` 0.1.11. As of this writing, that is the newest version of `xgboost` supported by `dask-xgboost`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "To begin, initialize an `ml_utils` object. This is a small object used to handle naming and storing the model."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -64,20 +71,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2020-08-07 19:23:15] INFO - dask-saturn | Cluster is ready\n"
+      "[2020-08-07 19:32:42] INFO - dask-saturn | Starting cluster. Status: stopped\n",
+      "[2020-08-07 19:32:48] INFO - dask-saturn | Starting cluster. Status: starting\n",
+      "[2020-08-07 19:33:00] INFO - dask-saturn | Starting cluster. Status: starting\n",
+      "[2020-08-07 19:33:26] INFO - dask-saturn | Cluster is ready\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0cf7e06a60ce4dfa98d6e371d3ce5cc8",
+       "model_id": "d6aef97342af4cebb191cb820a6c5c54",
        "version_major": 2,
        "version_minor": 0
       },
@@ -110,53 +120,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
-     "ename": "PermissionError",
-     "evalue": "Access Denied",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mClientError\u001b[0m                               Traceback (most recent call last)",
-      "\u001b[0;32m/srv/conda/envs/saturn/lib/python3.7/site-packages/s3fs/core.py\u001b[0m in \u001b[0;36m_lsdir\u001b[0;34m(self, path, refresh, max_items)\u001b[0m\n\u001b[1;32m    393\u001b[0m                 \u001b[0mdircache\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 394\u001b[0;31m                 \u001b[0;32mfor\u001b[0m \u001b[0mi\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mit\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    395\u001b[0m                     \u001b[0mdircache\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mextend\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mi\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'CommonPrefixes'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/srv/conda/envs/saturn/lib/python3.7/site-packages/botocore/paginate.py\u001b[0m in \u001b[0;36m__iter__\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    254\u001b[0m         \u001b[0;32mwhile\u001b[0m \u001b[0;32mTrue\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 255\u001b[0;31m             \u001b[0mresponse\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_make_request\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcurrent_kwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    256\u001b[0m             \u001b[0mparsed\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_extract_parsed_response\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mresponse\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/srv/conda/envs/saturn/lib/python3.7/site-packages/botocore/paginate.py\u001b[0m in \u001b[0;36m_make_request\u001b[0;34m(self, current_kwargs)\u001b[0m\n\u001b[1;32m    331\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m_make_request\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcurrent_kwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 332\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_method\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m**\u001b[0m\u001b[0mcurrent_kwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    333\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/srv/conda/envs/saturn/lib/python3.7/site-packages/botocore/client.py\u001b[0m in \u001b[0;36m_api_call\u001b[0;34m(self, *args, **kwargs)\u001b[0m\n\u001b[1;32m    275\u001b[0m             \u001b[0;31m# The \"self\" in this scope is referring to the BaseClient.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 276\u001b[0;31m             \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_make_api_call\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0moperation_name\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    277\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/srv/conda/envs/saturn/lib/python3.7/site-packages/botocore/client.py\u001b[0m in \u001b[0;36m_make_api_call\u001b[0;34m(self, operation_name, api_params)\u001b[0m\n\u001b[1;32m    585\u001b[0m             \u001b[0merror_class\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mexceptions\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfrom_code\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0merror_code\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 586\u001b[0;31m             \u001b[0;32mraise\u001b[0m \u001b[0merror_class\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mparsed_response\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0moperation_name\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    587\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mClientError\u001b[0m: An error occurred (AccessDenied) when calling the ListObjectsV2 operation: Access Denied",
-      "\nDuring handling of the above exception, another exception occurred:\n",
-      "\u001b[0;31mPermissionError\u001b[0m                           Traceback (most recent call last)",
-      "\u001b[0;32m<timed exec>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n",
-      "\u001b[0;32m/srv/conda/envs/saturn/lib/python3.7/site-packages/dask/dataframe/io/parquet/core.py\u001b[0m in \u001b[0;36mread_parquet\u001b[0;34m(path, columns, filters, categories, index, storage_options, engine, gather_statistics, split_row_groups, chunksize, **kwargs)\u001b[0m\n\u001b[1;32m    231\u001b[0m         \u001b[0mfilters\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mfilters\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    232\u001b[0m         \u001b[0msplit_row_groups\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0msplit_row_groups\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 233\u001b[0;31m         \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    234\u001b[0m     )\n\u001b[1;32m    235\u001b[0m     \u001b[0;32mif\u001b[0m \u001b[0mmeta\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mindex\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mname\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/srv/conda/envs/saturn/lib/python3.7/site-packages/dask/dataframe/io/parquet/arrow.py\u001b[0m in \u001b[0;36mread_metadata\u001b[0;34m(fs, paths, categories, index, gather_statistics, filters, split_row_groups, **kwargs)\u001b[0m\n\u001b[1;32m    137\u001b[0m         \u001b[0;31m# correspond to a row group (populated below)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    138\u001b[0m         parts, dataset = _determine_dataset_parts(\n\u001b[0;32m--> 139\u001b[0;31m             \u001b[0mfs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mpaths\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mgather_statistics\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfilters\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mkwargs\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"dataset\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m{\u001b[0m\u001b[0;34m}\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    140\u001b[0m         )\n\u001b[1;32m    141\u001b[0m         \u001b[0;31m# TODO: Call to `_determine_dataset_parts` uses `pq.ParquetDataset`\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/srv/conda/envs/saturn/lib/python3.7/site-packages/dask/dataframe/io/parquet/arrow.py\u001b[0m in \u001b[0;36m_determine_dataset_parts\u001b[0;34m(fs, paths, gather_statistics, filters, dataset_kwargs)\u001b[0m\n\u001b[1;32m     91\u001b[0m                 \u001b[0mdataset\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mpq\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mParquetDataset\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mpaths\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfilesystem\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mfs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mdataset_kwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     92\u001b[0m                 \u001b[0mparts\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0mbase\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0mfs\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msep\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0mfn\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0mfn\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mfns\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 93\u001b[0;31m     \u001b[0;32melif\u001b[0m \u001b[0mfs\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0misdir\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mpaths\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     94\u001b[0m         \u001b[0;31m# This is a directory, check for _metadata, then _common_metadata\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     95\u001b[0m         \u001b[0mallpaths\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfs\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mglob\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mpaths\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0mfs\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msep\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0;34m\"*\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/srv/conda/envs/saturn/lib/python3.7/site-packages/s3fs/core.py\u001b[0m in \u001b[0;36misdir\u001b[0;34m(self, path)\u001b[0m\n\u001b[1;32m    599\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    600\u001b[0m         \u001b[0;31m# This only returns things within the path and NOT the path object itself\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 601\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0mbool\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_lsdir\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mpath\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    602\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    603\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mls\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mpath\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdetail\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mFalse\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mrefresh\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mFalse\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/srv/conda/envs/saturn/lib/python3.7/site-packages/s3fs/core.py\u001b[0m in \u001b[0;36m_lsdir\u001b[0;34m(self, path, refresh, max_items)\u001b[0m\n\u001b[1;32m    407\u001b[0m                     \u001b[0mf\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'name'\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mf\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'Key'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    408\u001b[0m             \u001b[0;32mexcept\u001b[0m \u001b[0mClientError\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0me\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 409\u001b[0;31m                 \u001b[0;32mraise\u001b[0m \u001b[0mtranslate_boto_error\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0me\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    410\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    411\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdircache\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mpath\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfiles\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mPermissionError\u001b[0m: Access Denied"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 72.6 ms, sys: 8.05 ms, total: 80.7 ms\n",
+      "Wall time: 2.86 s\n"
      ]
     },
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "distributed.client - ERROR - Failed to reconnect to scheduler after 10.00 seconds, closing client\n",
-      "_GatheringFuture exception was never retrieved\n",
-      "future: <_GatheringFuture finished exception=CancelledError()>\n",
-      "concurrent.futures._base.CancelledError\n",
-      "tornado.application - ERROR - Exception in callback <function Cluster._widget.<locals>.update at 0x7ff556843710>\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/srv/conda/envs/saturn/lib/python3.7/site-packages/tornado/ioloop.py\", line 907, in _run\n",
-      "    return self.callback()\n",
-      "  File \"/srv/conda/envs/saturn/lib/python3.7/site-packages/distributed/deploy/cluster.py\", line 320, in update\n",
-      "    status.value = self._widget_status()\n",
-      "  File \"/srv/conda/envs/saturn/lib/python3.7/site-packages/distributed/deploy/cluster.py\", line 211, in _widget_status\n",
-      "    workers = len(self.scheduler_info[\"workers\"])\n",
-      "  File \"/srv/conda/envs/saturn/lib/python3.7/site-packages/dask_saturn/core.py\", line 139, in scheduler_info\n",
-      "    raise ValueError(\"Cluster is not running.\")\n",
-      "ValueError: Cluster is not running.\n"
-     ]
+     "data": {
+      "text/plain": [
+       "10994913"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -167,7 +150,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -296,7 +279,7 @@
        "4               166              1.0      0.169231  "
       ]
      },
-     "execution_count": 4,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -310,37 +293,28 @@
    "metadata": {},
    "source": [
     "<br>\n",
-    "Take a sample of the training data, then drop the full `train` to save memory."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(1099491, 10)"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "sample = tip_train.sample(frac=0.1, replace=False, random_state=42)\n",
-    "sample.shape"
+    "Take a sample of the training data."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1099492"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "del tip_train"
+    "sample = tip_train.sample(frac=0.1, replace=False, random_state=42)\n",
+    "len(sample)"
    ]
   },
   {
@@ -351,19 +325,10 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 7,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "xgb_reg = dxgb.train(\n",
-    "    client=client,\n",
-    "    objective=\"reg:squarederror\",\n",
-    "    learning_rate=0.1,\n",
-    "    max_depth=8,\n",
-    "    n_estimators=100,\n",
-    "    nthread=32\n",
-    ")"
+    "To be sure that the estimate of training time doesn't include data I/O, `persist()` the dataframe to the workers in the Dask cluster first."
    ]
   },
   {
@@ -372,11 +337,155 @@
    "metadata": {},
    "outputs": [
     {
+     "data": {
+      "text/html": [
+       "<div><strong>Dask DataFrame Structure:</strong></div>\n",
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>pickup_taxizone_id</th>\n",
+       "      <th>dropoff_taxizone_id</th>\n",
+       "      <th>pickup_weekday</th>\n",
+       "      <th>pickup_weekofyear</th>\n",
+       "      <th>pickup_hour</th>\n",
+       "      <th>pickup_minute</th>\n",
+       "      <th>pickup_week_hour</th>\n",
+       "      <th>passenger_count</th>\n",
+       "      <th>tip_fraction</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>npartitions=19</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <td>object</td>\n",
+       "      <td>float64</td>\n",
+       "      <td>float64</td>\n",
+       "      <td>int64</td>\n",
+       "      <td>int64</td>\n",
+       "      <td>int64</td>\n",
+       "      <td>int64</td>\n",
+       "      <td>int64</td>\n",
+       "      <td>float64</td>\n",
+       "      <td>float64</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>\n",
+       "<div>Dask Name: sample, 19 tasks</div>"
+      ],
+      "text/plain": [
+       "Dask DataFrame Structure:\n",
+       "                    id pickup_taxizone_id dropoff_taxizone_id pickup_weekday pickup_weekofyear pickup_hour pickup_minute pickup_week_hour passenger_count tip_fraction\n",
+       "npartitions=19                                                                                                                                                        \n",
+       "                object            float64             float64          int64             int64       int64         int64            int64         float64      float64\n",
+       "                   ...                ...                 ...            ...               ...         ...           ...              ...             ...          ...\n",
+       "...                ...                ...                 ...            ...               ...         ...           ...              ...             ...          ...\n",
+       "                   ...                ...                 ...            ...               ...         ...           ...              ...             ...          ...\n",
+       "                   ...                ...                 ...            ...               ...         ...           ...              ...             ...          ...\n",
+       "Dask Name: sample, 19 tasks"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sample.persist()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 9min 52s, sys: 11.6 s, total: 10min 4s\n",
-      "Wall time: 19.1 s\n"
+      "CPU times: user 58.3 ms, sys: 7.48 ms, total: 65.8 ms\n",
+      "Wall time: 40.1 s\n"
      ]
     }
    ],
@@ -384,7 +493,21 @@
     "%%time\n",
     "features = ml_utils.tip_vars.features\n",
     "y_col = ml_utils.tip_vars.y_col\n",
-    "model = xgb_reg.fit(X=sample[features], y=sample[y_col].values)"
+    "\n",
+    "xgb_reg = dxgb.train(\n",
+    "    client=client,\n",
+    "    params={\n",
+    "        \"verbosity\": 1,\n",
+    "        \"max_depth\": 8,\n",
+    "        \"random_state\": 42,\n",
+    "        \"objective\": \"reg:squarederror\",\n",
+    "        \"nthread\": 1,\n",
+    "        \"learning_rate\": 0.1\n",
+    "    },\n",
+    "    data=sample[features],\n",
+    "    labels=sample[y_col],\n",
+    "    num_boost_round=100\n",
+    ")"
    ]
   },
   {
@@ -398,20 +521,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "uploading model to 's3://saturn-titan/nyc-taxi/ml_results/models/tip__scikit__xgboost.pkl'\n",
+      "uploading model to 's3://saturn-titan/nyc-taxi/ml_results/models/tip__dask__xgboost.pkl'\n",
       "successfully uploaded model\n"
      ]
     }
    ],
    "source": [
-    "ml_utils.write_model(model)"
+    "ml_utils.write_model(xgb_reg)"
    ]
   },
   {
@@ -420,51 +543,46 @@
    "source": [
     "## Predict on test set\n",
     "\n",
-    "And calculate metrics. Save predictions and metrics to S3. Before doing that, remove the training data from memory."
+    "And calculate metrics. Save predictions and metrics to S3."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "del sample"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 15 s, sys: 11.5 s, total: 26.5 s\n",
-      "Wall time: 1min 4s\n"
+      "CPU times: user 77.9 ms, sys: 468 µs, total: 78.4 ms\n",
+      "Wall time: 190 ms\n"
      ]
     }
    ],
    "source": [
     "%%time\n",
-    "amt_test = ml_utils.read_parquet_dir(f'{ml_utils.taxi_path}/data/ml/tip_test')\n",
+    "amt_test = dd.read_parquet(f'{ml_utils.taxi_path}/data/ml/tip_test', engine='pyarrow')\n",
     "preds = amt_test[['id', y_col]].copy()\n",
     "preds.columns = ['id', 'actual']"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
-    "preds['predicted'] = model.predict(amt_test[features])"
+    "preds['predicted'] = dxgb.predict(\n",
+    "    client=client,\n",
+    "    model=xgb_reg,\n",
+    "    data=amt_test[features]\n",
+    ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
@@ -498,31 +616,31 @@
        "      <th>0</th>\n",
        "      <td>8e8109754e3e4cb7879c4e9ee216d58d</td>\n",
        "      <td>0.097087</td>\n",
-       "      <td>0.161691</td>\n",
+       "      <td>0.162214</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>a30e7c87866f417ab15dee5617f272a0</td>\n",
        "      <td>0.166667</td>\n",
-       "      <td>0.158902</td>\n",
+       "      <td>0.161161</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>1a7a611d0809489d99a5120727e0476a</td>\n",
        "      <td>0.120000</td>\n",
-       "      <td>0.158882</td>\n",
+       "      <td>0.158262</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>736e84ca12a640cc858c210bd58f744c</td>\n",
        "      <td>0.089474</td>\n",
-       "      <td>0.157415</td>\n",
+       "      <td>0.151156</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
        "      <td>f2c24299d9a34ce986b7a271c5cc80b2</td>\n",
        "      <td>0.000000</td>\n",
-       "      <td>0.147651</td>\n",
+       "      <td>0.158260</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -530,14 +648,14 @@
       ],
       "text/plain": [
        "                                 id    actual  predicted\n",
-       "0  8e8109754e3e4cb7879c4e9ee216d58d  0.097087   0.161691\n",
-       "1  a30e7c87866f417ab15dee5617f272a0  0.166667   0.158902\n",
-       "2  1a7a611d0809489d99a5120727e0476a  0.120000   0.158882\n",
-       "3  736e84ca12a640cc858c210bd58f744c  0.089474   0.157415\n",
-       "4  f2c24299d9a34ce986b7a271c5cc80b2  0.000000   0.147651"
+       "0  8e8109754e3e4cb7879c4e9ee216d58d  0.097087   0.162214\n",
+       "1  a30e7c87866f417ab15dee5617f272a0  0.166667   0.161161\n",
+       "2  1a7a611d0809489d99a5120727e0476a  0.120000   0.158262\n",
+       "3  736e84ca12a640cc858c210bd58f744c  0.089474   0.151156\n",
+       "4  f2c24299d9a34ce986b7a271c5cc80b2  0.000000   0.158260"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -548,17 +666,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Writing predictions to 's3://saturn-titan/nyc-taxi/ml_results/predictions/tip__scikit__xgboost'\n",
+      "Writing predictions to 's3://saturn-titan/nyc-taxi/ml_results/predictions/tip__dask__xgboost'\n",
       "Done writing predictions\n",
-      "CPU times: user 10.1 s, sys: 2.1 s, total: 12.2 s\n",
-      "Wall time: 1min 12s\n"
+      "CPU times: user 163 ms, sys: 23.6 ms, total: 187 ms\n",
+      "Wall time: 7.36 s\n"
      ]
     }
    ],
@@ -569,7 +687,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
@@ -604,21 +722,21 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>tip</td>\n",
-       "      <td>scikit</td>\n",
+       "      <td>dask</td>\n",
        "      <td>xgboost</td>\n",
        "      <td>rmse</td>\n",
-       "      <td>0.05157</td>\n",
+       "      <td>0.052061</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "  ml_task    tool    model metric    value\n",
-       "0     tip  scikit  xgboost   rmse  0.05157"
+       "  ml_task  tool    model metric     value\n",
+       "0     tip  dask  xgboost   rmse  0.052061"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/taxi_demo/machine_learning/tip_dask_xgboost.ipynb
+++ b/taxi_demo/machine_learning/tip_dask_xgboost.ipynb
@@ -136,6 +136,27 @@
       "\u001b[0;32m/srv/conda/envs/saturn/lib/python3.7/site-packages/s3fs/core.py\u001b[0m in \u001b[0;36m_lsdir\u001b[0;34m(self, path, refresh, max_items)\u001b[0m\n\u001b[1;32m    407\u001b[0m                     \u001b[0mf\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'name'\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mf\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'Key'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    408\u001b[0m             \u001b[0;32mexcept\u001b[0m \u001b[0mClientError\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0me\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 409\u001b[0;31m                 \u001b[0;32mraise\u001b[0m \u001b[0mtranslate_boto_error\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0me\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    410\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    411\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdircache\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mpath\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfiles\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
       "\u001b[0;31mPermissionError\u001b[0m: Access Denied"
      ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "distributed.client - ERROR - Failed to reconnect to scheduler after 10.00 seconds, closing client\n",
+      "_GatheringFuture exception was never retrieved\n",
+      "future: <_GatheringFuture finished exception=CancelledError()>\n",
+      "concurrent.futures._base.CancelledError\n",
+      "tornado.application - ERROR - Exception in callback <function Cluster._widget.<locals>.update at 0x7ff556843710>\n",
+      "Traceback (most recent call last):\n",
+      "  File \"/srv/conda/envs/saturn/lib/python3.7/site-packages/tornado/ioloop.py\", line 907, in _run\n",
+      "    return self.callback()\n",
+      "  File \"/srv/conda/envs/saturn/lib/python3.7/site-packages/distributed/deploy/cluster.py\", line 320, in update\n",
+      "    status.value = self._widget_status()\n",
+      "  File \"/srv/conda/envs/saturn/lib/python3.7/site-packages/distributed/deploy/cluster.py\", line 211, in _widget_status\n",
+      "    workers = len(self.scheduler_info[\"workers\"])\n",
+      "  File \"/srv/conda/envs/saturn/lib/python3.7/site-packages/dask_saturn/core.py\", line 139, in scheduler_info\n",
+      "    raise ValueError(\"Cluster is not running.\")\n",
+      "ValueError: Cluster is not running.\n"
+     ]
     }
    ],
    "source": [

--- a/taxi_demo/machine_learning/tip_scikit_xgboost.ipynb
+++ b/taxi_demo/machine_learning/tip_scikit_xgboost.ipynb
@@ -11,17 +11,41 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
     "import pandas as pd\n",
+    "import xgboost\n",
     "\n",
     "from sklearn.metrics import mean_squared_error\n",
-    "from xgboost import XGBRegressor\n",
     "\n",
     "from ml_utils import MLUtils"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook relies on `xgboost` 0.90. As of this writing, that is the newest version of `xgboost` supported by `dask-xgboost`, and this notebook is intended to compliment `tip_dask_xgboost.ipynb`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.90\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(xgboost.__version__)"
    ]
   },
   {
@@ -272,7 +296,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "xgb_reg = XGBRegressor(\n",
+    "xgb_reg = xgboost.XGBRegressor(\n",
     "    objective=\"reg:squarederror\",\n",
     "    learning_rate=0.1,\n",
     "    max_depth=8,\n",

--- a/taxi_demo/machine_learning/tip_scikit_xgboost.ipynb
+++ b/taxi_demo/machine_learning/tip_scikit_xgboost.ipynb
@@ -1,0 +1,568 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Tip Prediction (XGBoost)\n",
+    "\n",
+    "**Hardware**: r5.8xlarge (32 CPU, 256 GB RAM)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "from sklearn.compose import ColumnTransformer\n",
+    "from sklearn.metrics import mean_squared_error\n",
+    "from sklearn.pipeline import Pipeline\n",
+    "from sklearn.preprocessing import StandardScaler\n",
+    "\n",
+    "from xgboost import XGBRegressor\n",
+    "\n",
+    "from ml_utils import MLUtils"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To begin, initialize an `ml_utils` object. This is a small object used to handle naming and storing the model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ml_utils = MLUtils(\n",
+    "    ml_task='tip',\n",
+    "    tool='scikit',\n",
+    "    model='xgboost',\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Load data and feature engineering"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 6.04 s, sys: 3.2 s, total: 9.23 s\n",
+      "Wall time: 27.6 s\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "(10994913, 10)"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "tip_train = ml_utils.read_parquet_dir(f'{ml_utils.taxi_path}/data/ml/tip_train_sample')\n",
+    "tip_train.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>pickup_taxizone_id</th>\n",
+       "      <th>dropoff_taxizone_id</th>\n",
+       "      <th>pickup_weekday</th>\n",
+       "      <th>pickup_weekofyear</th>\n",
+       "      <th>pickup_hour</th>\n",
+       "      <th>pickup_minute</th>\n",
+       "      <th>pickup_week_hour</th>\n",
+       "      <th>passenger_count</th>\n",
+       "      <th>tip_fraction</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>28a18fa5fa2f44f29ffd98fc9159829d</td>\n",
+       "      <td>238.0</td>\n",
+       "      <td>132.0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>29</td>\n",
+       "      <td>7</td>\n",
+       "      <td>19</td>\n",
+       "      <td>7</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.199616</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>a6578145ff824f5fb94e90457b040883</td>\n",
+       "      <td>236.0</td>\n",
+       "      <td>246.0</td>\n",
+       "      <td>6</td>\n",
+       "      <td>28</td>\n",
+       "      <td>9</td>\n",
+       "      <td>16</td>\n",
+       "      <td>153</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.130435</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>91726ecac3b44e8bbfea68d725f35556</td>\n",
+       "      <td>90.0</td>\n",
+       "      <td>148.0</td>\n",
+       "      <td>6</td>\n",
+       "      <td>28</td>\n",
+       "      <td>22</td>\n",
+       "      <td>44</td>\n",
+       "      <td>166</td>\n",
+       "      <td>6.0</td>\n",
+       "      <td>0.166667</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>a3b0d14ad1644dd6b90f1af6be002e55</td>\n",
+       "      <td>141.0</td>\n",
+       "      <td>186.0</td>\n",
+       "      <td>6</td>\n",
+       "      <td>28</td>\n",
+       "      <td>9</td>\n",
+       "      <td>34</td>\n",
+       "      <td>153</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.152299</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>70aa5a0c6bc147dd8553e201b63ba0fe</td>\n",
+       "      <td>100.0</td>\n",
+       "      <td>142.0</td>\n",
+       "      <td>6</td>\n",
+       "      <td>28</td>\n",
+       "      <td>22</td>\n",
+       "      <td>7</td>\n",
+       "      <td>166</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.169231</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                 id  pickup_taxizone_id  dropoff_taxizone_id  \\\n",
+       "0  28a18fa5fa2f44f29ffd98fc9159829d               238.0                132.0   \n",
+       "1  a6578145ff824f5fb94e90457b040883               236.0                246.0   \n",
+       "2  91726ecac3b44e8bbfea68d725f35556                90.0                148.0   \n",
+       "3  a3b0d14ad1644dd6b90f1af6be002e55               141.0                186.0   \n",
+       "4  70aa5a0c6bc147dd8553e201b63ba0fe               100.0                142.0   \n",
+       "\n",
+       "   pickup_weekday  pickup_weekofyear  pickup_hour  pickup_minute  \\\n",
+       "0               0                 29            7             19   \n",
+       "1               6                 28            9             16   \n",
+       "2               6                 28           22             44   \n",
+       "3               6                 28            9             34   \n",
+       "4               6                 28           22              7   \n",
+       "\n",
+       "   pickup_week_hour  passenger_count  tip_fraction  \n",
+       "0                 7              1.0      0.199616  \n",
+       "1               153              1.0      0.130435  \n",
+       "2               166              6.0      0.166667  \n",
+       "3               153              1.0      0.152299  \n",
+       "4               166              1.0      0.169231  "
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tip_train.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<br>\n",
+    "Take a sample of the training data, then drop the full `train` to save memory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(1099491, 10)"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sample = tip_train.sample(frac=0.1, replace=False, random_state=42)\n",
+    "sample.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "del tip_train"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Train a model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "features = ml_utils.tip_vars.features\n",
+    "y_col = ml_utils.tip_vars.y_col\n",
+    "\n",
+    "pipeline = Pipeline(steps=[\n",
+    "    ('preprocess', ColumnTransformer(transformers=[\n",
+    "        ('num', StandardScaler(), ml_utils.tip_vars.numeric_feat),\n",
+    "    ])),\n",
+    "    ('reg', XGBRegressor(objective=\"reg:squarederror\", learning_rate=0.1, max_depth=8, n_estimators=100, nthread=32)),\n",
+    "])\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 8min 39s, sys: 10.9 s, total: 8min 50s\n",
+      "Wall time: 16.9 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "model = pipeline.fit(X=sample[features], y=sample[y_col].values)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Save model\n",
+    "\n",
+    "Now that we've trained a model, store it in S3 so it can be deployed in the future."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ml_utils.write_model(model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Predict on test set\n",
+    "\n",
+    "And calculate metrics. Save predictions and metrics to S3. Before doing that, remove the training data from memory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "del sample"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 14.7 s, sys: 11.2 s, total: 25.9 s\n",
+      "Wall time: 1min 7s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "amt_test = ml_utils.read_parquet_dir(f'{ml_utils.taxi_path}/data/ml/tip_test')\n",
+    "preds = amt_test[['id', y_col]].copy()\n",
+    "preds.columns = ['id', 'actual']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "preds['predicted'] = model.predict(amt_test[features])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>actual</th>\n",
+       "      <th>predicted</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>8e8109754e3e4cb7879c4e9ee216d58d</td>\n",
+       "      <td>0.097087</td>\n",
+       "      <td>0.154524</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>a30e7c87866f417ab15dee5617f272a0</td>\n",
+       "      <td>0.166667</td>\n",
+       "      <td>0.154331</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1a7a611d0809489d99a5120727e0476a</td>\n",
+       "      <td>0.120000</td>\n",
+       "      <td>0.156496</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>736e84ca12a640cc858c210bd58f744c</td>\n",
+       "      <td>0.089474</td>\n",
+       "      <td>0.158147</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>f2c24299d9a34ce986b7a271c5cc80b2</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.150408</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                 id    actual  predicted\n",
+       "0  8e8109754e3e4cb7879c4e9ee216d58d  0.097087   0.154524\n",
+       "1  a30e7c87866f417ab15dee5617f272a0  0.166667   0.154331\n",
+       "2  1a7a611d0809489d99a5120727e0476a  0.120000   0.156496\n",
+       "3  736e84ca12a640cc858c210bd58f744c  0.089474   0.158147\n",
+       "4  f2c24299d9a34ce986b7a271c5cc80b2  0.000000   0.150408"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "preds.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 10.1 s, sys: 2.41 s, total: 12.5 s\n",
+      "Wall time: 1min 14s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "ml_utils.write_predictions(preds)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>ml_task</th>\n",
+       "      <th>tool</th>\n",
+       "      <th>model</th>\n",
+       "      <th>metric</th>\n",
+       "      <th>value</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>tip</td>\n",
+       "      <td>scikit</td>\n",
+       "      <td>xgboost</td>\n",
+       "      <td>rmse</td>\n",
+       "      <td>0.052267</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  ml_task    tool    model metric     value\n",
+       "0     tip  scikit  xgboost   rmse  0.052267"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rmse = mean_squared_error(preds.actual, preds.predicted, squared=False)\n",
+    "ml_utils.write_metric_df('rmse', rmse)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/taxi_demo/machine_learning/tip_scikit_xgboost.ipynb
+++ b/taxi_demo/machine_learning/tip_scikit_xgboost.ipynb
@@ -11,18 +11,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
     "import pandas as pd\n",
     "\n",
-    "from sklearn.compose import ColumnTransformer\n",
     "from sklearn.metrics import mean_squared_error\n",
-    "from sklearn.pipeline import Pipeline\n",
-    "from sklearn.preprocessing import StandardScaler\n",
-    "\n",
     "from xgboost import XGBRegressor\n",
     "\n",
     "from ml_utils import MLUtils"
@@ -37,7 +33,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -57,15 +53,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 6.04 s, sys: 3.2 s, total: 9.23 s\n",
-      "Wall time: 27.6 s\n"
+      "CPU times: user 5.07 s, sys: 4.53 s, total: 9.6 s\n",
+      "Wall time: 28.8 s\n"
      ]
     },
     {
@@ -74,7 +70,7 @@
        "(10994913, 10)"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -87,7 +83,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -216,7 +212,7 @@
        "4               166              1.0      0.169231  "
       ]
      },
-     "execution_count": 12,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -235,7 +231,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -244,7 +240,7 @@
        "(1099491, 10)"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -256,7 +252,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -272,38 +268,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
-    "features = ml_utils.tip_vars.features\n",
-    "y_col = ml_utils.tip_vars.y_col\n",
-    "\n",
-    "pipeline = Pipeline(steps=[\n",
-    "    ('preprocess', ColumnTransformer(transformers=[\n",
-    "        ('num', StandardScaler(), ml_utils.tip_vars.numeric_feat),\n",
-    "    ])),\n",
-    "    ('reg', XGBRegressor(objective=\"reg:squarederror\", learning_rate=0.1, max_depth=8, n_estimators=100, nthread=32)),\n",
-    "])\n"
+    "xgb_reg = XGBRegressor(\n",
+    "    objective=\"reg:squarederror\",\n",
+    "    learning_rate=0.1,\n",
+    "    max_depth=8,\n",
+    "    n_estimators=100,\n",
+    "    nthread=32\n",
+    ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 8min 39s, sys: 10.9 s, total: 8min 50s\n",
-      "Wall time: 16.9 s\n"
+      "CPU times: user 9min 52s, sys: 11.6 s, total: 10min 4s\n",
+      "Wall time: 19.1 s\n"
      ]
     }
    ],
    "source": [
     "%%time\n",
-    "model = pipeline.fit(X=sample[features], y=sample[y_col].values)"
+    "features = ml_utils.tip_vars.features\n",
+    "y_col = ml_utils.tip_vars.y_col\n",
+    "model = xgb_reg.fit(X=sample[features], y=sample[y_col].values)"
    ]
   },
   {
@@ -317,9 +313,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "uploading model to 's3://saturn-titan/nyc-taxi/ml_results/models/tip__scikit__xgboost.pkl'\n",
+      "successfully uploaded model\n"
+     ]
+    }
+   ],
    "source": [
     "ml_utils.write_model(model)"
    ]
@@ -335,7 +340,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -344,15 +349,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 14.7 s, sys: 11.2 s, total: 25.9 s\n",
-      "Wall time: 1min 7s\n"
+      "CPU times: user 15 s, sys: 11.5 s, total: 26.5 s\n",
+      "Wall time: 1min 4s\n"
      ]
     }
    ],
@@ -365,7 +370,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -374,7 +379,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -408,31 +413,31 @@
        "      <th>0</th>\n",
        "      <td>8e8109754e3e4cb7879c4e9ee216d58d</td>\n",
        "      <td>0.097087</td>\n",
-       "      <td>0.154524</td>\n",
+       "      <td>0.161691</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>a30e7c87866f417ab15dee5617f272a0</td>\n",
        "      <td>0.166667</td>\n",
-       "      <td>0.154331</td>\n",
+       "      <td>0.158902</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>1a7a611d0809489d99a5120727e0476a</td>\n",
        "      <td>0.120000</td>\n",
-       "      <td>0.156496</td>\n",
+       "      <td>0.158882</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>736e84ca12a640cc858c210bd58f744c</td>\n",
        "      <td>0.089474</td>\n",
-       "      <td>0.158147</td>\n",
+       "      <td>0.157415</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
        "      <td>f2c24299d9a34ce986b7a271c5cc80b2</td>\n",
        "      <td>0.000000</td>\n",
-       "      <td>0.150408</td>\n",
+       "      <td>0.147651</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -440,14 +445,14 @@
       ],
       "text/plain": [
        "                                 id    actual  predicted\n",
-       "0  8e8109754e3e4cb7879c4e9ee216d58d  0.097087   0.154524\n",
-       "1  a30e7c87866f417ab15dee5617f272a0  0.166667   0.154331\n",
-       "2  1a7a611d0809489d99a5120727e0476a  0.120000   0.156496\n",
-       "3  736e84ca12a640cc858c210bd58f744c  0.089474   0.158147\n",
-       "4  f2c24299d9a34ce986b7a271c5cc80b2  0.000000   0.150408"
+       "0  8e8109754e3e4cb7879c4e9ee216d58d  0.097087   0.161691\n",
+       "1  a30e7c87866f417ab15dee5617f272a0  0.166667   0.158902\n",
+       "2  1a7a611d0809489d99a5120727e0476a  0.120000   0.158882\n",
+       "3  736e84ca12a640cc858c210bd58f744c  0.089474   0.157415\n",
+       "4  f2c24299d9a34ce986b7a271c5cc80b2  0.000000   0.147651"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -458,15 +463,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 10.1 s, sys: 2.41 s, total: 12.5 s\n",
-      "Wall time: 1min 14s\n"
+      "Writing predictions to 's3://saturn-titan/nyc-taxi/ml_results/predictions/tip__scikit__xgboost'\n",
+      "Done writing predictions\n",
+      "CPU times: user 10.1 s, sys: 2.1 s, total: 12.2 s\n",
+      "Wall time: 1min 12s\n"
      ]
     }
    ],
@@ -477,7 +484,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -515,18 +522,18 @@
        "      <td>scikit</td>\n",
        "      <td>xgboost</td>\n",
        "      <td>rmse</td>\n",
-       "      <td>0.052267</td>\n",
+       "      <td>0.05157</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "  ml_task    tool    model metric     value\n",
-       "0     tip  scikit  xgboost   rmse  0.052267"
+       "  ml_task    tool    model metric    value\n",
+       "0     tip  scikit  xgboost   rmse  0.05157"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -535,13 +542,6 @@
     "rmse = mean_squared_error(preds.actual, preds.predicted, squared=False)\n",
     "ml_utils.write_metric_df('rmse', rmse)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
This PR proposes two demo notebooks:

* single-node: XGBoost `scikit-learn` API on one `r5.8xlarge`
* Dask: `dask-xgboost` with a Dask cluster of 10 `r5.8xlarge` instances

These notebooks use `xgboost` 0.90 because that's the latest version that works with `dask-xgboost`. The Dask notebook uses `dask-xgboost` 0.1.11, the latest release.

This PR also adds some logging to the utils code used to write to S3. That code will now print a message telling you where in S3 it wrote things to.