### PR TITLE
random forest with rapids and snowflake on full taxi data

### DIFF
--- a/machine_learning/random_forest/rf-rapids-snowflake.ipynb
+++ b/machine_learning/random_forest/rf-rapids-snowflake.ipynb
@@ -1,0 +1,587 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Random forest classification\n",
+    "\n",
+    "## Dask + RAPIDS GPU cluster with Snowflake\n",
+    "\n",
+    "<table>\n",
+    "    <tr>\n",
+    "        <td>\n",
+    "            <img src=\"https://docs.dask.org/en/latest/_images/dask_horizontal.svg\" width=\"300\">\n",
+    "        </td>\n",
+    "        <td>\n",
+    "            <img src=\"https://rapids.ai/assets/images/RAPIDS-logo-purple.svg\" width=\"300\">\n",
+    "        </td>\n",
+    "        <td>\n",
+    "            <img src=\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/ff/Snowflake_Logo.svg/1280px-Snowflake_Logo.svg.png\" width=\"300\">\n",
+    "        </td>\n",
+    "    </tr>\n",
+    "</table>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "MODEL_PATH = 'models'\n",
+    "if not os.path.exists(MODEL_PATH):\n",
+    "    os.makedirs(MODEL_PATH)\n",
+    "    \n",
+    "numeric_feat = [\n",
+    "    'pickup_weekday', \n",
+    "    'pickup_weekofyear', \n",
+    "    'pickup_hour', \n",
+    "    'pickup_week_hour', \n",
+    "    'pickup_minute', \n",
+    "    'passenger_count',\n",
+    "]\n",
+    "categorical_feat = [\n",
+    "    'pickup_taxizone_id', \n",
+    "    'dropoff_taxizone_id',\n",
+    "]\n",
+    "features = numeric_feat + categorical_feat\n",
+    "y_col = 'high_tip'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Initialize Dask GPU cluster"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[2020-11-09 15:58:03] INFO - dask-saturn | Cluster is ready\n"
+     ]
+    }
+   ],
+   "source": [
+    "from dask.distributed import Client, wait\n",
+    "import time\n",
+    "from dask import persist\n",
+    "from dask_saturn import SaturnCluster\n",
+    "\n",
+    "n_workers = 20\n",
+    "cluster = SaturnCluster(n_workers=n_workers, scheduler_size='g4dnxlarge', worker_size='g4dnxlarge')\n",
+    "client = Client(cluster)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Open the dashboard (link ^) and watch it when you execute some commands, you'll see which tasks are running across the cluster. There are a couple other dashboard pages worth viewing for GPU memory and utilization that are not listed on the navbar, so we grab direct links for those below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<b>GPU Dashboard links</b>\n",
+       "<ul>\n",
+       "<li><a href=\"https://d-hugo-snowflake-blog.demo.saturnenterprise.io/individual-gpu-memory\" target=\"_blank\">GPU memory</a></li>\n",
+       "<li><a href=\"https://d-hugo-snowflake-blog.demo.saturnenterprise.io/individual-gpu-utilization\" target=\"_blank\">GPU utilization</a></li>\n",
+       "</ul>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from IPython.display import display, HTML\n",
+    "\n",
+    "gpu_links = f'''\n",
+    "<b>GPU Dashboard links</b>\n",
+    "<ul>\n",
+    "<li><a href=\"{client.dashboard_link}/individual-gpu-memory\" target=\"_blank\">GPU memory</a></li>\n",
+    "<li><a href=\"{client.dashboard_link}/individual-gpu-utilization\" target=\"_blank\">GPU utilization</a></li>\n",
+    "</ul>\n",
+    "'''\n",
+    "display(HTML(gpu_links))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you created your cluster here in this notebook, it might take a few minutes for all your nodes to become available. You can run the chunk below to block until all nodes are ready.\n",
+    "\n",
+    ">**Pro tip**: Create and/or start your cluster from the \"Dask\" page in Saturn if you want to get a head start!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client.wait_for_workers(n_workers=n_workers)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Load data and feature engineering\n",
+    "\n",
+    "Load a full month for this exercise. Note we are loading the data with Dask+RAPIDS now (`dask_cudf.read_csv` vs. `pd.read_csv`)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import datetime\n",
+    "import pandas as pd\n",
+    "import dask.dataframe as dd\n",
+    "import cudf\n",
+    "import dask_cudf as cudd\n",
+    "import warnings\n",
+    "warnings.simplefilter(\"ignore\")\n",
+    "\n",
+    "import snowflake.connector\n",
+    "\n",
+    "SNOWFLAKE_ACCOUNT = os.environ['SNOWFLAKE_ACCOUNT']\n",
+    "SNOWFLAKE_USER = os.environ['SNOWFLAKE_USER']\n",
+    "SNOWFLAKE_PASSWORD = os.environ['SNOWFLAKE_PASSWORD']\n",
+    "\n",
+    "SNOWFLAKE_WAREHOUSE = os.environ['SNOWFLAKE_WAREHOUSE']\n",
+    "TAXI_DATABASE = os.environ['TAXI_DATABASE']\n",
+    "TAXI_SCHEMA = os.environ['TAXI_SCHEMA']\n",
+    "\n",
+    "conn_info = {\n",
+    "    'account': SNOWFLAKE_ACCOUNT,\n",
+    "    'user': SNOWFLAKE_USER,\n",
+    "    'password': SNOWFLAKE_PASSWORD,\n",
+    "    'warehouse': SNOWFLAKE_WAREHOUSE,\n",
+    "    'database': TAXI_DATABASE,\n",
+    "    'schema': TAXI_SCHEMA,\n",
+    "}\n",
+    "conn = snowflake.connector.connect(**conn_info)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dask import delayed\n",
+    "\n",
+    "query = \"\"\"\n",
+    "SELECT \n",
+    "    pickup_taxizone_id,\n",
+    "    dropoff_taxizone_id,\n",
+    "    passenger_count,\n",
+    "    DIV0(tip_amount, fare_amount) > 0.2 AS high_tip,\n",
+    "    DAYOFWEEKISO(pickup_datetime) - 1 AS pickup_weekday,\n",
+    "    WEEKOFYEAR(pickup_datetime) AS pickup_weekofyear,\n",
+    "    HOUR(pickup_datetime) AS pickup_hour,\n",
+    "    (pickup_weekday * 24) + pickup_hour AS pickup_week_hour,\n",
+    "    MINUTE(pickup_datetime) AS pickup_minute\n",
+    "FROM taxi_yellow2\n",
+    "WHERE\n",
+    "    DATE(pickup_datetime) = %s\n",
+    "\"\"\"\n",
+    "\n",
+    "@delayed\n",
+    "def load(conn_info, query, day):\n",
+    "    with snowflake.connector.connect(**conn_info) as conn:\n",
+    "        taxi = conn.cursor().execute(query, day).fetch_pandas_all()\n",
+    "        taxi.columns = [x.lower() for x in taxi.columns]\n",
+    "        taxi = cudf.from_pandas(taxi)\n",
+    "        return taxi"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_dates(start, end):\n",
+    "    date_query = \"\"\"\n",
+    "    SELECT\n",
+    "        DISTINCT(DATE(pickup_datetime)) as date \n",
+    "    FROM taxi_yellow\n",
+    "    WHERE\n",
+    "        pickup_datetime BETWEEN %s and %s\n",
+    "    \"\"\"\n",
+    "    dates_df = conn.cursor().execute(date_query, (start, end))\n",
+    "    columns = [x[0] for x in dates_df.description]\n",
+    "    dates_df = pd.DataFrame(dates_df.fetchall(), columns=columns)\n",
+    "    return dates_df['DATE'].tolist()\n",
+    "\n",
+    "dates = get_dates('2017-01-01', '2019-12-31')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "taxi = cudd.from_delayed([load(conn_info, query, day) for day in dates])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Dask performs computations in a [lazy manner](https://tutorial.dask.org/01x_lazy.html), so we persist the dataframe to perform data loading and feature processing and load into GPU memory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "taxi_train = taxi[features + [y_col]]\n",
+    "taxi_train[features] = taxi_train[features].astype(\"float32\").fillna(-1)\n",
+    "taxi_train[y_col] = taxi_train[y_col].astype(\"int32\").fillna(-1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "taxi_train = taxi_train.persist()\n",
+    "_ = wait(taxi_train)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Num rows: 300698204, Size: 10825.135344 MB\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f'Num rows: {len(taxi_train)}, Size: {taxi_train.memory_usage(deep=True).compute().sum() / 1e6} MB')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "high_tip\n",
+       "1    151325359\n",
+       "0    149372845\n",
+       "Name: high_tip, dtype: int64"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "taxi_train.groupby('high_tip')['high_tip'].count().compute()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>pickup_weekday</th>\n",
+       "      <th>pickup_weekofyear</th>\n",
+       "      <th>pickup_hour</th>\n",
+       "      <th>pickup_week_hour</th>\n",
+       "      <th>pickup_minute</th>\n",
+       "      <th>passenger_count</th>\n",
+       "      <th>pickup_taxizone_id</th>\n",
+       "      <th>dropoff_taxizone_id</th>\n",
+       "      <th>high_tip</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>5.0</td>\n",
+       "      <td>42.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>120.0</td>\n",
+       "      <td>32.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>113.0</td>\n",
+       "      <td>230.0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>5.0</td>\n",
+       "      <td>42.0</td>\n",
+       "      <td>9.0</td>\n",
+       "      <td>129.0</td>\n",
+       "      <td>33.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>238.0</td>\n",
+       "      <td>239.0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>5.0</td>\n",
+       "      <td>42.0</td>\n",
+       "      <td>9.0</td>\n",
+       "      <td>129.0</td>\n",
+       "      <td>45.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>239.0</td>\n",
+       "      <td>163.0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>5.0</td>\n",
+       "      <td>42.0</td>\n",
+       "      <td>7.0</td>\n",
+       "      <td>127.0</td>\n",
+       "      <td>48.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>158.0</td>\n",
+       "      <td>231.0</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>5.0</td>\n",
+       "      <td>42.0</td>\n",
+       "      <td>8.0</td>\n",
+       "      <td>128.0</td>\n",
+       "      <td>7.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>209.0</td>\n",
+       "      <td>232.0</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   pickup_weekday  pickup_weekofyear  pickup_hour  pickup_week_hour  \\\n",
+       "0             5.0               42.0          0.0             120.0   \n",
+       "1             5.0               42.0          9.0             129.0   \n",
+       "2             5.0               42.0          9.0             129.0   \n",
+       "3             5.0               42.0          7.0             127.0   \n",
+       "4             5.0               42.0          8.0             128.0   \n",
+       "\n",
+       "   pickup_minute  passenger_count  pickup_taxizone_id  dropoff_taxizone_id  \\\n",
+       "0           32.0              1.0               113.0                230.0   \n",
+       "1           33.0              2.0               238.0                239.0   \n",
+       "2           45.0              2.0               239.0                163.0   \n",
+       "3           48.0              1.0               158.0                231.0   \n",
+       "4            7.0              1.0               209.0                232.0   \n",
+       "\n",
+       "   high_tip  \n",
+       "0         0  \n",
+       "1         0  \n",
+       "2         0  \n",
+       "3         1  \n",
+       "4         1  "
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "taxi_train.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Train model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from cuml.dask.ensemble import RandomForestClassifier\n",
+    "rfc = RandomForestClassifier(n_estimators=100, max_depth=10, seed=42)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 1.72 s, sys: 253 ms, total: 1.97 s\n",
+      "Wall time: 7.33 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "_ = rfc.fit(taxi_train[features], taxi_train[y_col])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Calculate metrics on test set\n",
+    "\n",
+    "Use a different month for test set"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_dates = get_dates('2020-01-01', '2020-03-01')\n",
+    "taxi_test = cudd.from_delayed([load(conn_info, query, day) for day in test_dates])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "taxi_test = taxi_test[features + [y_col]]\n",
+    "taxi_test[features] = taxi_test[features].astype(\"float32\").fillna(-1)\n",
+    "taxi_test[y_col] = taxi_test[y_col].astype(\"int32\").fillna(-1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "taxi_test = taxi_test.persist()\n",
+    "_ = wait(taxi_test)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<br>\n",
+    "\n",
+    "Convert to single-GPU DataFrame using `compute()` because the Dask+RAPIDS implementation doesnt yet have `roc_auc_score`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.5315331220626831"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from cuml.metrics import roc_auc_score\n",
+    "\n",
+    "preds = rfc.predict_proba(taxi_test[features])[1]\n",
+    "roc_auc_score(taxi_test[y_col].compute(), preds.compute())"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Same notebook from here: https://github.com/saturncloud/examples/blob/main/examples/examples-gpu/nyc-taxi-snowflake/rf-rapids-dask.ipynb

Except use full nyc taxi data. We don't want to put in customer examples because it requires a large cluster