### PR TITLE
[DEV-1598] remove old conda channels

### DIFF
--- a/machine_learning/random_forest/environment.yml
+++ b/machine_learning/random_forest/environment.yml
@@ -1,12 +1,10 @@
 name: saturn
 channels:
-- https://conda.saturncloud.io/pkgs
 - nvidia
 - rapidsai
 - numba
 - defaults
 - conda-forge
-- saturncloud
 dependencies:
 - blas=*=mkl
 - python=3.7

--- a/taxi_demo/environment.yml
+++ b/taxi_demo/environment.yml
@@ -2,7 +2,6 @@ name: taxi-demo
 channels:
 - defaults
 - pytorch
-- saturncloud
 - conda-forge
 dependencies:
 - blas=*=mkl

--- a/taxi_demo/gpu_environment.yml
+++ b/taxi_demo/gpu_environment.yml
@@ -1,13 +1,11 @@
 name: taxi-demo
 channels:
-- https://conda.saturncloud.io/pkgs
 - nvidia
 - rapidsai
 - pytorch
 - numba
 - defaults
 - conda-forge
-- saturncloud
 dependencies:
 - blas=*=mkl
 - bokeh


### PR DESCRIPTION
I'm working on https://app.clickup.com/t/1250339/DEV-1598, removing old saturn conda channels from projects in the `saturncloud` GitHub org.

It looks like this project is using these in some environments, but that it doesn't actually rely on any packages in those channels.

This PR proposes removing those channels.

### How this improves `saturn-cloud-examples`

* might improve build times by reducing the search space for packages
* prevents the possibility of accidentally getting an old package due to a weird environment solve
* removes a possible source of supply chain attacks, where someone could try to sneak malicious code into our environments by uploading it to one of these conda channels